### PR TITLE
fix storefront ingress HTTP path port

### DIFF
--- a/charts/opencommerce/templates/storefront/storefront-ingress.yaml
+++ b/charts/opencommerce/templates/storefront/storefront-ingress.yaml
@@ -32,7 +32,7 @@ spec:
               service:      
                 name: {{ template "opencommerce.fullname" . }}-storefront
                 port:
-                  number: 4080          
+                  number: 4000         
       host: {{ .Values.storefront.host }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

The HTTP path port for the storefront's ingress was wrong, causing deployments to fail on EKS. With port 4000, all works well now.